### PR TITLE
Clean the build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,6 @@
 *.app
 
 out/*
+target/*
 *.3d
+*.xml

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-
-mkdir -p out
-cmake -S . -B out
-cd out || exit 1
+build_dir="target"
+mkdir -p $build_dir
+cmake -S src -B $build_dir
+cd $build_dir || exit 1
 make
 cd ..

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 project(globalProject)
 set(CMAKE_CXX_STANDARD 11)
-add_subdirectory(src/engine)
-add_subdirectory(src/common)
+add_subdirectory(engine)
+add_subdirectory(common)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
Remove on directory level needed to reach the executable and renamed build folder
before:
`out/src/engine/engine`
now:
`target/engine/engine`

